### PR TITLE
Add volume hint and replay button

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,10 @@
   </head>
   <body>
     <div id="message"></div>
+    <div id="after-animation">
+      <div id="volume-text">Play with volume on for full effect</div>
+      <button id="replay">Replay</button>
+    </div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,11 +3,19 @@ import { animate } from 'animejs';
 
 const message = 'HAPPY BIRTHDAY';
 const container = document.getElementById('message');
+const after = document.getElementById('after-animation');
+const replayButton = document.getElementById('replay');
 
-if (container) {
+if (replayButton) {
+  replayButton.addEventListener('click', () => {
+    window.location.reload();
+  });
+}
+if (container && after) {
   const letters = message.split('');
   const letterCount = message.replace(/\s+/g, '').length;
   let letterIndex = 0;
+  const animations: Promise<void>[] = [];
   letters.forEach((char) => {
     const span = document.createElement('span');
     span.className = 'letter';
@@ -27,7 +35,7 @@ if (container) {
 
     span.style.transform = `translate(${Math.cos(angle) * radius}px, ${Math.sin(angle) * radius}px)`;
 
-    animate(span, {
+    const anim = animate(span, {
       duration: 4000,
       easing: 'linear',
       onUpdate: (anim: any) => {
@@ -39,5 +47,11 @@ if (container) {
         span.style.transform = `translate(${x}px, ${y}px)`;
       },
     });
+    // anime.js exposes a `finished` promise
+    animations.push((anim as any).finished);
+  });
+
+  Promise.all(animations).then(() => {
+    after.classList.add('visible');
   });
 }

--- a/src/style.css
+++ b/src/style.css
@@ -108,3 +108,24 @@ button:focus-visible {
   display: inline-block;
   text-shadow: 0 0 10px currentColor;
 }
+
+#after-animation {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 1rem;
+  opacity: 0;
+  transition: opacity 1s;
+}
+
+#after-animation.visible {
+  opacity: 1;
+}
+
+#volume-text {
+  font-size: 1.5rem;
+}
+
+#replay {
+  margin-top: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add informational volume text and Replay button
- fade in new content after animation completes
- ensure Replay reloads the page

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687232dfec14832ca205c34dd9e9e0ad