### PR TITLE
Add volume hint and replay button

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,10 @@
   </head>
   <body>
     <div id="message"></div>
+    <div id="after-animation">
+      <div id="volume-text">Play with volume on for full effect</div>
+      <button id="replay">Replay</button>
+    </div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,8 +3,16 @@ import { animate } from 'animejs';
 
 const message = 'HAPPY BIRTHDAY';
 const container = document.getElementById('message');
+const after = document.getElementById('after-animation');
+const replayButton = document.getElementById('replay');
+const animationDuration = 4000;
 
-if (container) {
+if (replayButton) {
+  replayButton.addEventListener('click', () => {
+    window.location.reload();
+  });
+}
+if (container && after) {
   const letters = message.split('');
   const letterCount = message.replace(/\s+/g, '').length;
   let letterIndex = 0;
@@ -28,7 +36,7 @@ if (container) {
     span.style.transform = `translate(${Math.cos(angle) * radius}px, ${Math.sin(angle) * radius}px)`;
 
     animate(span, {
-      duration: 4000,
+      duration: animationDuration,
       easing: 'linear',
       onUpdate: (anim: any) => {
         const progress = anim.progress;
@@ -40,4 +48,8 @@ if (container) {
       },
     });
   });
+
+  window.setTimeout(() => {
+    after.classList.add('visible');
+  }, animationDuration);
 }

--- a/src/style.css
+++ b/src/style.css
@@ -25,6 +25,7 @@ a:hover {
 body {
   margin: 0;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   min-width: 320px;
@@ -107,4 +108,25 @@ button:focus-visible {
 .letter {
   display: inline-block;
   text-shadow: 0 0 10px currentColor;
+}
+
+#after-animation {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 1rem;
+  opacity: 0;
+  transition: opacity 1s;
+}
+
+#after-animation.visible {
+  opacity: 1;
+}
+
+#volume-text {
+  font-size: 1.5rem;
+}
+
+#replay {
+  margin-top: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- add informational volume text and Replay button
- fade in new content after animation completes
- align Replay content beneath the message

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687232dfec14832ca205c34dd9e9e0ad