### PR TITLE
Improve mobile layout

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -105,6 +105,12 @@ button:focus-visible {
   gap: 0.2em;
 }
 
+@media (max-width: 600px) {
+  #message {
+    font-size: 3.8vw;
+  }
+}
+
 .letter {
   display: inline-block;
   text-shadow: 0 0 10px currentColor;


### PR DESCRIPTION
## Summary
- adjust `#message` font size on small screens to occupy ~50% width

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68723755d6d8832cb1ed48f6f7934159