### PR TITLE
Improve mobile layout

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -11,6 +11,7 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  --message-font-size: 4rem;
 }
 
 a {
@@ -100,9 +101,15 @@ button:focus-visible {
 #message {
   display: flex;
   justify-content: center;
-  font-size: 4rem;
+  font-size: var(--message-font-size);
   font-weight: bold;
   gap: 0.2em;
+}
+
+@media (max-width: 600px) {
+  :root {
+    --message-font-size: 3.8vw;
+  }
 }
 
 .letter {
@@ -124,7 +131,7 @@ button:focus-visible {
 }
 
 #volume-text {
-  font-size: 1.5rem;
+  font-size: calc(var(--message-font-size) * 0.375);
 }
 
 #replay {


### PR DESCRIPTION
## Summary
- link volume text font to message size using CSS variable
- scale message font through CSS custom property and media query

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68723755d6d8832cb1ed48f6f7934159