### PR TITLE
Fix mobile layout

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -11,6 +11,7 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  --message-font-size: min(6vw, 4rem);
 }
 
 a {
@@ -100,10 +101,11 @@ button:focus-visible {
 #message {
   display: flex;
   justify-content: center;
-  font-size: 4rem;
+  font-size: var(--message-font-size);
   font-weight: bold;
   gap: 0.2em;
 }
+
 
 .letter {
   display: inline-block;
@@ -124,7 +126,7 @@ button:focus-visible {
 }
 
 #volume-text {
-  font-size: 1.5rem;
+  font-size: calc(var(--message-font-size) * 0.375);
 }
 
 #replay {


### PR DESCRIPTION
## Summary
- size message based on viewport width to handle landscape phones
- drop media query so message shrinks responsively

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68723755d6d8832cb1ed48f6f7934159